### PR TITLE
Keycloak 24 support due to CookieHelper being deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.3
+FROM quay.io/keycloak/keycloak:24.0.3
 
 #COPY target/lib/*.jar ./providers/
 COPY spi/target/keycloak-spi-trusted-device-*-SNAPSHOT.jar /opt/keycloak/providers/keycloak-spi-trusted-device.jar

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <keycloak.version>22.0.3</keycloak.version>
+    <keycloak.version>24.0.3</keycloak.version>
     <lombok.version>1.18.30</lombok.version>
     <reproducible-build-maven-plugin.version>0.16</reproducible-build-maven-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>


### PR DESCRIPTION
This PR adds support for keycloak 24 because Keycloak refactored the [CookieHelper](https://github.com/keycloak/keycloak/issues/26503).
keycloak 24 did also introduce a replacement, but that one is [considered internal](https://github.com/keycloak/keycloak/issues/28235) and is not usable.

My java (ecosystem) knowledge is limited, but as far as i see it this does not add a BC break and is also usable for earlier keycloak versions.