### PR TITLE
Add the ability to make device name optional

### DIFF
--- a/spi/src/main/java/nl/wouterh/keycloak/trusteddevice/authenticator/RegisterTrustedDeviceAuthenticator.java
+++ b/spi/src/main/java/nl/wouterh/keycloak/trusteddevice/authenticator/RegisterTrustedDeviceAuthenticator.java
@@ -1,5 +1,6 @@
 package nl.wouterh.keycloak.trusteddevice.authenticator;
 
+import static nl.wouterh.keycloak.trusteddevice.authenticator.RegisterTrustedDeviceAuthenticatorFactory.CONF_DEVICE_NAME_REQUIRED;
 import static nl.wouterh.keycloak.trusteddevice.authenticator.RegisterTrustedDeviceAuthenticatorFactory.CONF_DURATION;
 
 import com.google.common.base.Strings;
@@ -52,9 +53,25 @@ public class RegisterTrustedDeviceAuthenticator implements Authenticator {
     } else {
       Response form = context.form()
           .setAttribute("trustedDeviceName", UserAgentParser.getDeviceName(session))
+          .setAttribute("deviceNameRequired", isDeviceNameRequired(context.getAuthenticatorConfig()))
           .createForm("trusted-device-register.ftl");
       context.challenge(form);
     }
+  }
+
+  private static boolean isDeviceNameRequired(AuthenticatorConfigModel authenticatorConfig) {
+    if (authenticatorConfig == null) {
+      return true;
+    }
+    Map<String, String> config = authenticatorConfig.getConfig();
+    if (config == null) {
+      return true;
+    }
+    String value = config.get(CONF_DEVICE_NAME_REQUIRED);
+    if (Strings.isNullOrEmpty(value)) {
+      return true;
+    }
+    return Boolean.parseBoolean(value);
   }
 
   @Override
@@ -78,13 +95,15 @@ public class RegisterTrustedDeviceAuthenticator implements Authenticator {
       }
     }
 
+    boolean deviceNameRequired = isDeviceNameRequired(authenticatorConfig);
+
     MultivaluedMap<String, String> formParameters = context.getHttpRequest()
         .getDecodedFormParameters();
 
     boolean trustedDevice = "yes".equals(formParameters.getFirst("trusted-device"));
     String deviceName = formParameters.getFirst("trusted-device-name");
 
-    if (trustedDevice && !Strings.isNullOrEmpty(deviceName)) {
+    if (trustedDevice && (!deviceNameRequired || !Strings.isNullOrEmpty(deviceName))) {
       TrustedDeviceCredentialProvider trustedDeviceCredentialProvider = (TrustedDeviceCredentialProvider) session.getProvider(
           CredentialProvider.class, TrustedDeviceCredentialProviderFactory.PROVIDER_ID);
 
@@ -93,14 +112,17 @@ public class RegisterTrustedDeviceAuthenticator implements Authenticator {
       secureRandom.nextBytes(bytes);
       String deviceId = Hex.encodeHexString(bytes);
 
-      // Expire the token in 1 year
       Long exp = null;
-      String credentialName = deviceName;
       if (duration != null) {
         exp = Time.currentTime() + duration.getSeconds();
+      }
 
-        credentialName = String.format("%s (Expires: %s)", deviceName,
-            formatter.format(Instant.ofEpochSecond(exp)));
+      String credentialName = null;
+      if (!Strings.isNullOrEmpty(deviceName)) {
+        credentialName = exp != null
+            ? String.format("%s (Expires: %s)", deviceName,
+                formatter.format(Instant.ofEpochSecond(exp)))
+            : deviceName;
       }
 
       TrustedDeviceCredentialModel trustedDeviceCredentialModel = TrustedDeviceCredentialModel.create(

--- a/spi/src/main/java/nl/wouterh/keycloak/trusteddevice/authenticator/RegisterTrustedDeviceAuthenticatorFactory.java
+++ b/spi/src/main/java/nl/wouterh/keycloak/trusteddevice/authenticator/RegisterTrustedDeviceAuthenticatorFactory.java
@@ -16,6 +16,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 public class RegisterTrustedDeviceAuthenticatorFactory implements AuthenticatorFactory {
 
   public static final String CONF_DURATION = "duration";
+  public static final String CONF_DEVICE_NAME_REQUIRED = "deviceNameRequired";
 
   public static final String PROVIDER_ID = "trusted-device-authenticator";
 
@@ -60,7 +61,15 @@ public class RegisterTrustedDeviceAuthenticatorFactory implements AuthenticatorF
     duration.setHelpText(
         "Duration the device will be trusted. Input format is a Java Duration, for example P365d or PT24h. Empty value means forever.");
 
-    return Arrays.asList(duration);
+    ProviderConfigProperty deviceNameRequired = new ProviderConfigProperty();
+    deviceNameRequired.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+    deviceNameRequired.setName(CONF_DEVICE_NAME_REQUIRED);
+    deviceNameRequired.setLabel("Require device name");
+    deviceNameRequired.setDefaultValue("true");
+    deviceNameRequired.setHelpText(
+        "If enabled, the user is prompted to name the device and registration is skipped if the name is blank. If disabled, trusting the device is a single click and the parsed User-Agent (e.g. \"Chrome on Windows\") is used as the label; if the User-Agent can't be parsed, the credential is stored without a label.");
+
+    return Arrays.asList(duration, deviceNameRequired);
   }
 
   @Override

--- a/spi/src/main/resources/theme-resources/templates/trusted-device-register.ftl
+++ b/spi/src/main/resources/theme-resources/templates/trusted-device-register.ftl
@@ -13,21 +13,23 @@
             </div>
           </div>
 
-          <script>
-            function inputName(e) {
-              const elem = document.querySelector("#kc-trusted-device-name");
-              const result = prompt("${msg("trusted-device-name")}", elem.value);
-              if (result === null) {
-                e.preventDefault();
-                return false;
+          <#if deviceNameRequired>
+            <script>
+              function inputName(e) {
+                const elem = document.querySelector("#kc-trusted-device-name");
+                const result = prompt("${msg("trusted-device-name")}", elem.value);
+                if (result === null) {
+                  e.preventDefault();
+                  return false;
+                }
+
+                elem.value = result;
               }
+            </script>
 
-              elem.value = result;
-            }
-          </script>
-
-          <input type="hidden" id="kc-trusted-device-name" name="trusted-device-name"
-                 value="${trustedDeviceName}"/>
+            <input type="hidden" id="kc-trusted-device-name" name="trusted-device-name"
+                   value="${trustedDeviceName!''}"/>
+          </#if>
 
           <div class="${properties.kcFormButtonsClass!}">
               <#if (auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
@@ -37,8 +39,7 @@
                 class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                 name="trusted-device" id="kc-trusted-device-yes"
                 type="submit"
-                value="yes"
-                onclick="inputName(event)">
+                value="yes"<#if deviceNameRequired> onclick="inputName(event)"</#if>>
                 ${msg("trusted-device-yes")}
             </button>
 


### PR DESCRIPTION
This PR adds adds a new boolean config property `Require device name` to the Register Trusted Device authenticator. The flag defaults to `true`, preserving existing behavior. When the flag is disabled, trusting the device becomes a single click without display the device name prompt.